### PR TITLE
fix: Add ParseCareKit.plist to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ DerivedData/
 *.perspectivev3
 !default.perspectivev3
 xcuserdata/
+OCKSample/Supporting Files/ParseCareKit.plist
 
 ## Other
 *.moved-aside


### PR DESCRIPTION
Add the server settings file to the .gitignore so updated changes are not captured.

In the future, you will just share `OCKSample/Supporting Files/ParseCareKit.plist` privately with your teamates